### PR TITLE
some editor files

### DIFF
--- a/{{ cookiecutter.repo_name }}/.gitignore
+++ b/{{ cookiecutter.repo_name }}/.gitignore
@@ -61,7 +61,17 @@ docs/source/generated/
 target/
 
 # Editor files
+#mac
+.DS_Store
+*~
+
+#vim
 *.swp
+*.swo
+
+#pycharm
+.idea/*
+
 
 #Ipython Notebook
 .ipynb_checkpoints


### PR DESCRIPTION
Small edit. Found these in another gitignore.

Should we also ignore .tiff etc? The user could still explicitly add them.

```
#Binary data files
*.volume
*.am
*.tiff
*.tif
*.dat
*.DAT
```