### PR TITLE
Make orgname clearer

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "full_name": "Name or Organization",
     "email": "",
-    "github_username": "",
+    "github_orgname": "",
     "project_name": "Your Project Name",
     "package_dist_name": "{{ cookiecutter.project_name|replace(' ', '-')|lower }}",
     "package_dir_name": "{{ cookiecutter.project_name|replace(' ', '_')|lower }}",

--- a/{{ cookiecutter.repo_name }}/CONTRIBUTING.rst
+++ b/{{ cookiecutter.repo_name }}/CONTRIBUTING.rst
@@ -13,7 +13,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at https://github.com/{{ cookiecutter.github_orgname;g }}/{{ cookiecutter.repo_name }}/issues.
+Report bugs at https://github.com/{{ cookiecutter.github_orgname }}/{{ cookiecutter.repo_name }}/issues.
 
 If you are reporting a bug, please include:
 
@@ -42,7 +42,7 @@ or even on the web in blog posts, articles, and such.
 Submit Feedback
 ~~~~~~~~~~~~~~~
 
-The best way to send feedback is to file an issue at https://github.com/{{ cookiecutter.github_orgname;g }}/{{ cookiecutter.repo_name }}/issues.
+The best way to send feedback is to file an issue at https://github.com/{{ cookiecutter.github_orgname }}/{{ cookiecutter.repo_name }}/issues.
 
 If you are proposing a feature:
 
@@ -99,6 +99,6 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
 3. The pull request should work for Python 2.7, 3.3, 3.4, 3.5 and for PyPy. Check
-   https://travis-ci.org/{{ cookiecutter.github_orgname;g }}/{{ cookiecutter.repo_name }}/pull_requests
+   https://travis-ci.org/{{ cookiecutter.github_orgname }}/{{ cookiecutter.repo_name }}/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/{{ cookiecutter.repo_name }}/CONTRIBUTING.rst
+++ b/{{ cookiecutter.repo_name }}/CONTRIBUTING.rst
@@ -13,7 +13,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}/issues.
+Report bugs at https://github.com/{{ cookiecutter.github_orgname;g }}/{{ cookiecutter.repo_name }}/issues.
 
 If you are reporting a bug, please include:
 
@@ -42,7 +42,7 @@ or even on the web in blog posts, articles, and such.
 Submit Feedback
 ~~~~~~~~~~~~~~~
 
-The best way to send feedback is to file an issue at https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}/issues.
+The best way to send feedback is to file an issue at https://github.com/{{ cookiecutter.github_orgname;g }}/{{ cookiecutter.repo_name }}/issues.
 
 If you are proposing a feature:
 
@@ -99,6 +99,6 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
 3. The pull request should work for Python 2.7, 3.3, 3.4, 3.5 and for PyPy. Check
-   https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}/pull_requests
+   https://travis-ci.org/{{ cookiecutter.github_orgname;g }}/{{ cookiecutter.repo_name }}/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/{{ cookiecutter.repo_name }}/README.rst
+++ b/{{ cookiecutter.repo_name }}/README.rst
@@ -2,8 +2,8 @@
 {{ cookiecutter.project_name }}
 ===============================
 
-.. image:: https://img.shields.io/travis/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}.svg
-        :target: https://travis-ci.org/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}
+.. image:: https://img.shields.io/travis/{{ cookiecutter.github_orgname }}/{{ cookiecutter.repo_name }}.svg
+        :target: https://travis-ci.org/{{ cookiecutter.github_orgname }}/{{ cookiecutter.repo_name }}
 
 .. image:: https://img.shields.io/pypi/v/{{ cookiecutter.repo_name }}.svg
         :target: https://pypi.python.org/pypi/{{ cookiecutter.repo_name }}
@@ -12,7 +12,7 @@
 {{ cookiecutter.project_short_description}}
 
 * Free software: 3-clause BSD license
-* Documentation: (COMING SOON!) https://{{ cookiecutter.github_username}}.github.io/{{ cookiecutter.repo_name }}.
+* Documentation: (COMING SOON!) https://{{ cookiecutter.github_orgname}}.github.io/{{ cookiecutter.repo_name }}.
 
 Features
 --------

--- a/{{ cookiecutter.repo_name }}/setup.py
+++ b/{{ cookiecutter.repo_name }}/setup.py
@@ -41,7 +41,7 @@ setup(
     long_description=readme,
     author="{{ cookiecutter.full_name }}",
     author_email='{{ cookiecutter.email }}',
-    url='https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.repo_name }}',
+    url='https://github.com/{{ cookiecutter.github_orgname }}/{{ cookiecutter.repo_name }}',
     packages=find_packages(exclude=['docs', 'tests']),
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Just because I made the silly mistake "jrmlhermitte" as github user name when trying to make GeRM a scinetific package.

I think we should write orgname to be clear.
For ex: we prob want nsls-ii-chx.github.io not yugangzhang.github.io/ in readme etc.