### PR TITLE
DOC: Add a link to a related tutorial.

### DIFF
--- a/docs/source/further-reading.rst
+++ b/docs/source/further-reading.rst
@@ -6,6 +6,7 @@ Other Tutorials and Articles
 ----------------------------
 
 * `Official Python Packaging Guide <https://packaging.python.org/>`_
+* `"SettingUpOpenSource" lesson plans by John Leeman <https://jrleeman.github.io/SettingUpOpenSource>`_
 
 Other Python Cookiecutters
 --------------------------


### PR DESCRIPTION
Perusing the SciPy tutorials, I found teaching materials that seem to have a
goal similar to this one. It's more like an outline for in-person instruction,
not something that a user could follow on their own, but still useful to link to.