### PR TITLE
ENH: Add sphinx-copybutton extension to docs in and about cookiecutter.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,7 +41,9 @@ extensions = [
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
     'matplotlib.sphinxext.plot_directive',
-    'numpydoc']
+    'numpydoc',
+    'sphinx_copybutton',
+]
 
 # Configuration options for plot_directive. See:
 # https://github.com/matplotlib/matplotlib/blob/f3ed922d935751e08494e5fb5311d3050a3b637b/lib/matplotlib/sphinxext/plot_directive.py#L81

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ numpy
 numpydoc
 pexpect
 sphinx
+sphinx-copybutton
 sphinx_rtd_theme

--- a/{{ cookiecutter.repo_name }}/docs/source/conf.py
+++ b/{{ cookiecutter.repo_name }}/docs/source/conf.py
@@ -41,7 +41,9 @@ extensions = [
     'IPython.sphinxext.ipython_directive',
     'IPython.sphinxext.ipython_console_highlighting',
     'matplotlib.sphinxext.plot_directive',
-    'numpydoc']
+    'numpydoc',
+    'sphinx_copybutton',
+]
 
 # Configuration options for plot_directive. See:
 # https://github.com/matplotlib/matplotlib/blob/f3ed922d935751e08494e5fb5311d3050a3b637b/lib/matplotlib/sphinxext/plot_directive.py#L81

--- a/{{ cookiecutter.repo_name }}/requirements-dev.txt
+++ b/{{ cookiecutter.repo_name }}/requirements-dev.txt
@@ -8,4 +8,5 @@ matplotlib
 numpydoc
 pytest
 sphinx
+sphinx-copybutton
 sphinx_rtd_theme


### PR DESCRIPTION
This adds a copy-to-clipboard button to every code-block.

See https://github.com/choldgraf/sphinx-copybutton

Thanks @choldgraf! :-D